### PR TITLE
fix(ADS-2013): added log4j-appender to the connect release task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3197,6 +3197,8 @@ tasks.create(name: "connectReleaseTarGz", type: Tar) {
         from(project(pkg).jar) { into("libs/") }
         from(project(pkg).configurations.runtimeClasspath) { into("libs/") }
     }
+    from(project(':log4j-appender').jar) { into("libs/") }
+    from(project(':log4j-appender').configurations.runtimeClasspath) { into("libs/") }
 
     duplicatesStrategy 'exclude'
 


### PR DESCRIPTION
Fixed missing slf4j-reload4j jar in the connect distribution
